### PR TITLE
Remove -Werror flag

### DIFF
--- a/Builds/CMake/CompileOptions.cmake
+++ b/Builds/CMake/CompileOptions.cmake
@@ -93,7 +93,7 @@ endif ()
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(DEFAULT_COMPILE_OPTIONS ${DEFAULT_COMPILE_OPTIONS}
         -Wall
-        -Werror
+        #-Werror
         -std=c++1z
     )
 endif ()


### PR DESCRIPTION
-Werror flag is bad in term of long-term support.
It causes build fails for warnings that shouldn't have caused build fails