### PR TITLE
Fix example build error: added missing header

### DIFF
--- a/Includes/Utils/Serialization.h
+++ b/Includes/Utils/Serialization.h
@@ -12,6 +12,7 @@
 #include <Array/Array1.h>
 
 #include <vector>
+#include <cstring>
 
 namespace CubbyFlow
 {


### PR DESCRIPTION
```memcpy``` requires ```#incude <cstring>```